### PR TITLE
Getting Uncaught TypeError #290

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -445,6 +445,9 @@ class StreamController extends EventHandler {
 
   getBufferRange(position) {
     var i, range;
+    if(this.bufferRange === null ){
+      return;
+    }
     for (i = this.bufferRange.length - 1; i >=0; i--) {
       range = this.bufferRange[i];
       if (position >= range.start && position <= range.end) {


### PR DESCRIPTION
When I force switch bitrate index of a live stream by using "hls.nextLevel = CustomIndex" and When i try to access hls.currentLevel to display custom stats this line of code is throwing the following error.

Uncaught TypeError: Cannot read property 'length' of undefined
getBufferRange @ hls.js:1678
get @ hls.js:2385

Raised an issue https://github.com/dailymotion/hls.js/issues/290
