### PR TITLE
Handle `undefined` `bufferRange` in `getBufferRange` 

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -445,7 +445,7 @@ class StreamController extends EventHandler {
 
   getBufferRange(position) {
     var i, range;
-    if (typeof this.bufferRange !== "undefined") {
+    if (typeof this.bufferRange !== 'undefined') {
       for (i = this.bufferRange.length - 1; i >=0; i--) {
         range = this.bufferRange[i];
         if (position >= range.start && position <= range.end) {


### PR DESCRIPTION
Related to #290 
